### PR TITLE
reshape state array for a multiple-state element after solving the roots

### DIFF
--- a/superflexpy/utils/numerical_approximator.py
+++ b/superflexpy/utils/numerical_approximator.py
@@ -167,7 +167,7 @@ class NumericalApproximator():
                                       args=args,
                                       root_settings=root_settings))
 
-        return np.array(output).reshape((-1, len(fun)))
+        return np.array(output).reshape((len(fun), -1)).T
 
     def get_fluxes(self, fluxes, S, S0, **kwargs):
 


### PR DESCRIPTION
For example, an element with 2 states will have two flux functions: `[f1, f2]` and two s_zeros: `[S0_1, S0_2]`.
Let's say `S0_1` = `[0, 1, 2, 3, 4]` and `S0_2` = `[5, 6, 7, 8, 9]`, the current implementation of line 170 will return a `state_array` of:
```python
array([[1, 2],
       [3, 4],
       [5, 6],
       [7, 8]])
```
instead of:
```python
array([[1, 5],
       [2, 6],
       [3, 7],
       [4, 8]])
```

This means that when you call `get_states()[0]` on the element, it will return the first two values in `S0_1` instead of the first `S0_1` and `S0_2`.

The new modification solves the issue. I encountered this while developing a multi-state element for my class project.