### PR TITLE
Modernize `numba` function implementations

### DIFF
--- a/.github/workflows/automatic_test.yml
+++ b/.github/workflows/automatic_test.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-    matrix:
-      python-version: ["3.11", "3.12", "3.13"]
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Prepare the repo
         uses: actions/checkout@v4

--- a/.github/workflows/automatic_test.yml
+++ b/.github/workflows/automatic_test.yml
@@ -10,13 +10,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+    matrix:
+      python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Prepare the repo
-        uses: actions/checkout@master
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install packages
         run: pip install -r test/unittest/test_requirements.txt
       - name: Test

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - uses: pre-commit/action@v3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-matplotlib==3.8.2
-numba==0.57.1
-numpy==1.24.3
+matplotlib>=3.8.2
+numba>=0.57.1
+numpy>=1.24.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,1 @@
-pre-commit==3.5.0
+pre-commit>=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="superflexpy",
-    version="1.3.2",
+    version="1.3.3",
     author="Marco Dal Molin, Fabrizio Fenicia, Dmitri Kavetski",
     author_email="marco.dalmolin.1991@gmail.com",
     description="Framework for building hydrological models",
@@ -17,5 +17,5 @@ setuptools.setup(
         "Development Status :: 5 - Production/Stable",  # https://martin-thoma.com/software-development-stages/
         "Topic :: Scientific/Engineering :: Hydrology",
     ],
-    install_requires=["numba==0.57.1", "numpy==1.24.3"],
+    install_requires=["numba>=0.57.1", "numpy>=1.24.3"],
 )

--- a/superflexpy/implementation/elements/gr4j.py
+++ b/superflexpy/implementation/elements/gr4j.py
@@ -249,10 +249,27 @@ class ProductionStore(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
-        "(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
+        # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 3),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 3)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _flux_function_numba(S, S0, ind, P, x1, alpha, beta, ni, PET, dt):
         return (
@@ -392,10 +409,26 @@ class RoutingStore(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
-        "(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
+        # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 3),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 3)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _flux_function_numba(S, S0, ind, P, x2, x3, gamma, omega, dt):
         return (

--- a/superflexpy/implementation/elements/gr4j.py
+++ b/superflexpy/implementation/elements/gr4j.py
@@ -253,12 +253,7 @@ class ProductionStore(ODEsElement):
         # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
         # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 3),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 3)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 3), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 3)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
@@ -268,7 +263,7 @@ class ProductionStore(ODEsElement):
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _flux_function_numba(S, S0, ind, P, x1, alpha, beta, ni, PET, dt):
@@ -413,12 +408,7 @@ class RoutingStore(ODEsElement):
         # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
         # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 3),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 3)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 3), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 3)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
@@ -427,7 +417,7 @@ class RoutingStore(ODEsElement):
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _flux_function_numba(S, S0, ind, P, x2, x3, gamma, omega, dt):

--- a/superflexpy/implementation/elements/hbv.py
+++ b/superflexpy/implementation/elements/hbv.py
@@ -140,19 +140,14 @@ class PowerReservoir(ODEsElement):
     @nb.njit(
         # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 2),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 2)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 2), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 2)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _fluxes_function_numba(S, S0, ind, P, k, alpha, dt):
@@ -318,12 +313,7 @@ class UnsaturatedReservoir(ODEsElement):
         # "Tuple((UniTuple(f8, 3), f8, f8,UniTuple(f8, 3)))"
         # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 3),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 3)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 3), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 3)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
@@ -333,7 +323,7 @@ class UnsaturatedReservoir(ODEsElement):
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _fluxes_function_numba(S, S0, ind, P, Smax, Ce, m, beta, PET, dt):

--- a/superflexpy/implementation/elements/hbv.py
+++ b/superflexpy/implementation/elements/hbv.py
@@ -137,9 +137,23 @@ class PowerReservoir(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 2),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 2)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _fluxes_function_numba(S, S0, ind, P, k, alpha, dt):
         # This method is used only when solving the equation
@@ -300,10 +314,27 @@ class UnsaturatedReservoir(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 3), f8, f8,UniTuple(f8, 3)))"
-        "(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 3), f8, f8,UniTuple(f8, 3)))"
+        # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 3),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 3)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C", readonly=True),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _fluxes_function_numba(S, S0, ind, P, Smax, Ce, m, beta, PET, dt):
         # TODO: handle time variable parameters (Smax) -> overflow

--- a/superflexpy/implementation/elements/hymod.py
+++ b/superflexpy/implementation/elements/hymod.py
@@ -193,12 +193,7 @@ class UpperZone(ODEsElement):
         # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
         # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 3),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 3)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 3), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 3)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
@@ -207,7 +202,7 @@ class UpperZone(ODEsElement):
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _fluxes_function_numba(S, S0, ind, P, Smax, m, beta, PET, dt):
@@ -336,18 +331,13 @@ class LinearReservoir(ODEsElement):
     @staticmethod
     @nb.njit(
         # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i8, f8[:], f8[:], f8[:])", nopython=True
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 2),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 2)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 2), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 2)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _fluxes_function_numba(S, S0, ind, P, k, dt):

--- a/superflexpy/implementation/elements/hymod.py
+++ b/superflexpy/implementation/elements/hymod.py
@@ -189,10 +189,26 @@ class UpperZone(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
-        "(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 3), f8, f8, UniTuple(f8, 3)))"
+        # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 3),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 3)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _fluxes_function_numba(S, S0, ind, P, Smax, m, beta, PET, dt):
         # TODO: handle time variable parameters (Smax) -> overflow
@@ -318,8 +334,21 @@ class LinearReservoir(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i4, f8[:], f8[:], f8[:])", nopython=True
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))(optional(f8), f8, i8, f8[:], f8[:], f8[:])", nopython=True
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 2),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 2)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _fluxes_function_numba(S, S0, ind, P, k, dt):
         # This method is used only when solving the equation

--- a/superflexpy/implementation/elements/thur_model_hess.py
+++ b/superflexpy/implementation/elements/thur_model_hess.py
@@ -165,12 +165,7 @@ class SnowReservoir(ODEsElement):
         # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))"
         # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
         # nopython=True,
-        nb.types.Tuple((
-            nb.types.UniTuple(nb.float64, 2),
-            nb.float64,
-            nb.float64,
-            nb.types.UniTuple(nb.float64, 2)
-        ))(
+        nb.types.Tuple((nb.types.UniTuple(nb.float64, 2), nb.float64, nb.float64, nb.types.UniTuple(nb.float64, 2)))(
             nb.types.Optional(nb.float64),
             nb.float64,
             nb.int64,
@@ -179,7 +174,7 @@ class SnowReservoir(ODEsElement):
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
             nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
-            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
         )
     )
     def _flux_function_numba(S, S0, ind, snow, T, t0, k, m, dt):

--- a/superflexpy/implementation/elements/thur_model_hess.py
+++ b/superflexpy/implementation/elements/thur_model_hess.py
@@ -161,10 +161,26 @@ class SnowReservoir(ODEsElement):
             )
 
     @staticmethod
-    @nb.jit(
-        "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))"
-        "(optional(f8), f8, i4, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
-        nopython=True,
+    @nb.njit(
+        # "Tuple((UniTuple(f8, 2), f8, f8, UniTuple(f8, 2)))"
+        # "(optional(f8), f8, i8, f8[:], f8[:], f8[:], f8[:], f8[:], f8[:])",
+        # nopython=True,
+        nb.types.Tuple((
+            nb.types.UniTuple(nb.float64, 2),
+            nb.float64,
+            nb.float64,
+            nb.types.UniTuple(nb.float64, 2)
+        ))(
+            nb.types.Optional(nb.float64),
+            nb.float64,
+            nb.int64,
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C"),
+            nb.types.Array(dtype=nb.float64, ndim=1, layout="C")
+        )
     )
     def _flux_function_numba(S, S0, ind, snow, T, t0, k, m, dt):
         if S is None:

--- a/test/unittest/01_FR.py
+++ b/test/unittest/01_FR.py
@@ -67,7 +67,7 @@ class TestFR(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/01_FR/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/02_UR.py
+++ b/test/unittest/02_UR.py
@@ -72,7 +72,7 @@ class TestUR(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/02_UR/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/03_UR_FR.py
+++ b/test/unittest/03_UR_FR.py
@@ -83,7 +83,7 @@ class TestHRU(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/03_UR_FR/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/04_UR_FR_SR.py
+++ b/test/unittest/04_UR_FR_SR.py
@@ -89,7 +89,7 @@ class TestStructureElements(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/04_UR_FR_SR/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/05_2HRUs.py
+++ b/test/unittest/05_2HRUs.py
@@ -99,7 +99,7 @@ class TestStructureElements(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/05_2HRUs/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/06_3Cats_2HRUs.py
+++ b/test/unittest/06_3Cats_2HRUs.py
@@ -114,7 +114,7 @@ class TestStructureElements(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/06_3Cats_2HRUs/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation_c1 = data.iloc[:, 5].values

--- a/test/unittest/07_FR_2dt.py
+++ b/test/unittest/07_FR_2dt.py
@@ -67,7 +67,7 @@ class TestFR(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/07_FR_2dt/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/08_UR_2dt.py
+++ b/test/unittest/08_UR_2dt.py
@@ -72,7 +72,7 @@ class TestUR(unittest.TestCase):
         data = pd.read_csv(
             "{}/test/reference_results/08_UR_2dt/input.dat".format(package_path),
             header=6,
-            sep="\s+|,\s+|,",
+            sep=r"\s+|,\s+|,",
             engine="python",
         )
         self._precipitation = data.iloc[:, 6].values

--- a/test/unittest/test_requirements.txt
+++ b/test/unittest/test_requirements.txt
@@ -1,4 +1,4 @@
-pandas==2.1.3
-matplotlib==3.8.2
-numba==0.57.1
-numpy==1.24.3
+pandas>=2.1.3
+matplotlib>=3.8.2
+numba>=0.57.1
+numpy>=1.24.3


### PR DESCRIPTION
I'm a big fan of this package and hate to see it gather dust. Myself and a few colleagues would like to continue using it in modern Python environments. This PR adopts modern `numba` syntax for defining function signatures and allows use in newer versions of Python.

## Changes
 - `.github/workflows/automatic_test.yml` Update to recent versions of github actions. Add 3.12 and 3.13 at test environments.
 - `.github/workflows/pre_commit.yaml` Update to recent versions of github actions. Lock to Python 3.11 (attempts to use 3.14 otherwise).
 - `requirements.txt` Change from locked specific versions to minimum versions.
 - `requirements_dev.txt` Change from locked specific versions to minimum versions.
 - `setup.py` Change from locked specific versions to minimum versions. Bumps to version `1.3.3`.
 - `superflexpy/implementation/elements/gr4j.py` Update `numba` signatures. Note that `njit` is shorthand for `jit` with `nopython=True`
 - `superflexpy/implementation/elements/hbv.py` Update `numba` signatures.
 - `superflexpy/implementation/elements/hymod.py` Update `numba` signatures.
 - `superflexpy/implementation/elements/thur_model_hess.py` Update `numba` signatures.
 - `test/unittest/test_requirements.txt` Change from locked specific versions to minimum versions.

## Testing
Every test calls `pandas.read_csv` with `sep="\s+|,\s+|,"`. This PR changes this to `sep=r"\s+|,\s+|,"` to avoid `SyntaxWarning` in Python 3.12+.

Closes #12 